### PR TITLE
Add Junos Support

### DIFF
--- a/nsa/settings.py
+++ b/nsa/settings.py
@@ -49,4 +49,10 @@ class Settings(metaclass=Singleton):
             "nxos": [r"Cisco Nexus Operating System \(NX-OS\) Software",],
             "iosxe": [r"IOS-XE Software",],
             "iosxr": [r"RP0/CPU0",],
+            "junos": [
+                r"JUNOS",
+                # TC: Not 100% sure if this pattern is in other platforms
+                #     It'll do for now until a bug is opened
+                r"## Last commit: \d{4}-\d{2}-\d{2}.*by \w",
+            ],
         }

--- a/nsa/utils.py
+++ b/nsa/utils.py
@@ -31,6 +31,6 @@ def _detect_platform(line, pattern_type):
     )
     for platform, patterns in platform_patterns.items():
         for pattern in patterns:
-            if re.search(pattern, line):
+            if re.search(pattern, line, flags=re.IGNORECASE):
                 return platform
     return None


### PR DESCRIPTION
Adds Junos support by checking for `junos` or `## Last commit` strings.  Also updates platform detection to be case insensitive (previously, case mattered).

Closes #1.