### PR TITLE
Add a rule for IOS/IOSXE enable password

### DIFF
--- a/nsa/rules/20-generic-passwords.yml
+++ b/nsa/rules/20-generic-passwords.yml
@@ -1,0 +1,10 @@
+---
+
+rules:
+  - title: Unencrypted/weak `enable password`
+    pattern: enable password .+
+    operator: in
+    platforms:
+      - iosxe
+    score: 5.0
+    reason: Enable password should be disabled with `no enable password`


### PR DESCRIPTION
What it says on the tin.  Adds a rule to ensure that there is no `enable password` set.  #2 is partially resolved by this PR.  However, #5 needs to be resolved before #2 can be completely closed.